### PR TITLE
Add support for plugin reload on changes during runtime

### DIFF
--- a/mr_roboto.py
+++ b/mr_roboto.py
@@ -13,8 +13,8 @@ class ReloadEventHandler(FileSystemEventHandler):
     def on_modified(self, event):
         super(ReloadEventHandler, self).on_modified(event)
 
-        if event.src_path.endswith(".py") and \
-                os.path.dirname(event.src_path).endswith("plugins"):
+        if (event.src_path.endswith(".py") and
+            os.path.dirname(event.src_path).endswith("plugins")):
             local_plugins = filter(lambda lp: lp.startswith("plugins"),
                                    self.config["includes"])
             self.bot.reload(*local_plugins)

--- a/mr_roboto.py
+++ b/mr_roboto.py
@@ -1,17 +1,42 @@
 # -*- coding: utf-8 -*-
 from irc3 import IrcBot, utils
+from watchdog.observers import Observer
+from watchdog.events import FileSystemEventHandler
 import sys
+import os
 
+class ReloadEventHandler(FileSystemEventHandler):
+    def __init__(self, bot, config):
+        self.bot = bot
+        self.config = config
+
+    def on_modified(self, event):
+        super(ReloadEventHandler, self).on_modified(event)
+
+        if event.src_path.endswith(".py") and \
+                os.path.dirname(event.src_path).endswith("plugins"):
+            local_plugins = filter(lambda lp: lp.startswith("plugins"),
+                                   self.config["includes"])
+            self.bot.reload(*local_plugins)
 
 def main():
     # parse configs
     if len(sys.argv) != 2:
         print('Usage: mr_roboto <settings_file>')
         sys.exit(1)
-    config = utils.parse_config('bot', sys.argv[1])
+    config_path = os.path.abspath(sys.argv[1])
+    config = utils.parse_config('bot', config_path)
     # start bot
     bot = IrcBot.from_config(config)
-    bot.run(forever=True)
+    observer = Observer()
+    observer.schedule(ReloadEventHandler(bot, config),
+                      os.path.dirname(config_path), recursive=True)
+    observer.start()
+
+    try:
+        bot.run(forever=True)
+    except KeyboardInterrupt:
+        observer.stop()
 
 if __name__ == '__main__':
     main()

--- a/plugins/behaviors.py
+++ b/plugins/behaviors.py
@@ -26,6 +26,11 @@ class Behaviors(object):
             ('(https?://[^ \t>\n\r\x01-\x1f]+)', self.handle_url),
         ])
 
+    @classmethod
+    def reload(cls, old):
+        print("reloading plugin {}".format(cls.__name__))
+        return cls(old.bot)
+
     def compile_rules(self, rules):
         """
             Compile a list of RE and return a new list with

--- a/plugins/commands.py
+++ b/plugins/commands.py
@@ -19,6 +19,11 @@ class Commands(object):
     def __init__(self, bot):
         self.bot = bot
 
+    @classmethod
+    def reload(cls, old):
+        print("reloading plugin {}".format(cls.__name__))
+        return cls(old.bot)
+
     @command(permission='view')
     async def commit(self, mask, target, args):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ irc3==1.1.1
 lxml==4.2.3
 venusian==1.1.0
 redis==2.10.6
+watchdog==0.9.0

--- a/settings.sample.ini
+++ b/settings.sample.ini
@@ -1,21 +1,30 @@
 [bot]
 # bot info
 nick = mybot
+username = mybot
 password = password
 
 # channels to join
 autojoins =
-    mybot_channel
+    ${#}mybot_channel
 
 # server info
 host = localhost
 port = 6667
 
+# database info
+storage = redis://localhost:6379
+
 # plugins to include
 includes =
+    irc3.plugins.command
     irc3.plugins.log
     irc3.plugins.logger
-    irc3.plugins.core
     irc3.plugins.autojoins
     irc3.plugins.userlist
-    plugins.nickserv
+    irc3.plugins.storage
+    plugins.commands
+    plugins.behavior
+
+[irc3.plugins.command]
+cmd = !


### PR DESCRIPTION
This feature might be helpful during development phase, since it enables the developer to change plugins' source code and test it without the need to restart the bot. Some IRC servers will basically ban or block bot's IP address in case it connect/disconnect few times in a row. With this runtime reload we can avoid such situations.

However, only custom plugins are supported right now, those present on plugins/ folder and only changes on .py file. It's possible to extend this change checker, but for now it'll generate too much noise on debug output. Let's see how this feature will behave during some time, in case it's fine I can work on its increment.

At the same time I'm also updating settings.sample.ini file, to follow the current state of the project and also irc3 default plugins options.