### PR TITLE
plugins/behaviors: charset exception during html processing

### DIFF
--- a/plugins/behaviors.py
+++ b/plugins/behaviors.py
@@ -127,7 +127,14 @@ class Behaviors(object):
         """
         # MIME Type Handling functions
         def handle_text(target, subtype, data, charset):
-            content = str(data, encoding=charset)
+            try:
+                content = str(data, encoding=charset)
+            except UnicodeDecodeError as e:
+                # It's still possible that part of the site processing changes
+                # the encoding (i.e. ascii animations). Hence we try to find the
+                # title within the range with correct charset
+                content = str(data[:e.end-1], encoding=charset)
+
             page = html.fromstring(content)
             title = page.findtext('.//title')
 


### PR DESCRIPTION
It seems to be possible that some html+js scripts change/send chars not
specified on the html original encoding, breaking our current text handler that
tries to find website's title.

Because of that we need to catch the exception and try to find the title of the
website only within the "correct charset" range.