### PR TITLE
plugins/behaviors: handle no charset defined or guessed

### DIFF
--- a/plugins/behaviors.py
+++ b/plugins/behaviors.py
@@ -114,14 +114,21 @@ class Behaviors(BasePlugin):
             channel
         """
         # MIME Type Handling functions
-        def handle_text(target, subtype, data, charset):
+        def handle_text(target, subtype, data, charset='utf-8'):
             try:
                 content = str(data, encoding=charset)
             except UnicodeDecodeError as e:
                 # It's still possible that part of the site processing changes
                 # the encoding (i.e. ascii animations). Hence we try to find the
                 # title within the range with correct charset
-                content = str(data[:e.end-1], encoding=charset)
+                try:
+                    content = str(data[:e.end-1], encoding=charset)
+                except UnicodeDecodeError:
+                    # If it fails again, just forget it and return
+                    self.bot.privmsg(
+                        target,
+                        '... it seems this website has a pretty broken charset')
+                    return
 
             page = html.fromstring(content)
             title = page.findtext('.//title')
@@ -169,7 +176,7 @@ class Behaviors(BasePlugin):
 
         # Handle content
         if mime_type in type_handlers:
-            if mime_type == u'text':
+            if mime_type == u'text' and request.charset:
                 type_handlers[mime_type](target, subtype, data, request.charset)
             else:
                 type_handlers[mime_type](target, subtype, data)


### PR DESCRIPTION
In case no charset is returned by the request api, try to use utf-8 by default.
Also add a nested exception handler to catch the last possible situation where
nothing worked till that point.