### PR TITLE
plugins/behaviors: replacing hash sign messes with privmsg()

### DIFF
--- a/plugins/behaviors.py
+++ b/plugins/behaviors.py
@@ -78,10 +78,9 @@ class Behaviors(BasePlugin):
         """
         if self.bot.nick != mask.nick:
             message = '%s: Hi!' % mask.nick
-            channel = channel.replace('#', '')
             nick = mask.nick.lower()
             table = self.bot.dataset['greetings']
-            result = table.find_one(channel=channel, nick=nick) or {}
+            result = table.find_one(channel=channel.replace('#', ''), nick=nick) or {}
 
             if result.get('options', ''):
                 greeting = random.choice(result['options'].splitlines())


### PR DESCRIPTION
privmsg() method requires the hash sign for channels in order to send the msg to
it, while the database doesn't store the sign, thus the better option is just to
replace the hash for database calls.