### PR TITLE
hook: pre-commit hook for flake8 compliance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+- repo: https://gitlab.com/pycqa/flake8
+  # point to the patch that added hook support, since
+  # latest release (3.6.0) doesn't have support yet
+  rev: 93ad9617b0a192836cbc9a591b5abe74e2c85ba7
+  hooks:
+    - id: flake8
+      name: flake8 compliance
+

--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ verify_ssl = true
 flake8 = "*"
 ipdb = "*"
 appnope = {version = "*", sys_platform = "== 'darwin'"}
+pre-commit = "*"
 
 [packages]
 irc3 = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a22443cc2ffae0b6149f451a431e0c1731ad6ad125af08853c899e2b94331aa2"
+            "sha256": "483002ae9f1caa64fd6e80bd07b5c8dfbe7c2bfa78515ddfdbef42919856b617"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -346,12 +346,33 @@
             "markers": "sys_platform == 'darwin'",
             "version": "==0.1.0"
         },
+        "aspy.yaml": {
+            "hashes": [
+                "sha256:04d26279513618f1024e1aba46471db870b3b33aef204c2d09bcf93bea9ba13f",
+                "sha256:0a77e23fafe7b242068ffc0252cee130d3e509040908fc678d9d1060e7494baa"
+            ],
+            "version": "==1.1.1"
+        },
         "backcall": {
             "hashes": [
                 "sha256:38ecd85be2c1e78f77fd91700c76e14667dc21e2713b63876c0eb901196e01e4",
                 "sha256:bbbf4b1e5cd2bdb08f915895b51081c041bac22394fdfcfdfbe9f14b77c08bf2"
             ],
             "version": "==0.1.0"
+        },
+        "cached-property": {
+            "hashes": [
+                "sha256:3a026f1a54135677e7da5ce819b0c690f156f37976f3e30c5430740725203d7f",
+                "sha256:9217a59f14a5682da7c4b8829deadbfc194ac22e9908ccf7c8820234e80a1504"
+            ],
+            "version": "==1.5.1"
+        },
+        "cfgv": {
+            "hashes": [
+                "sha256:73f48a752bd7aab103c4b882d6596c6360b7aa63b34073dd2c35c7b4b8f93010",
+                "sha256:d1791caa9ff5c0c7bce80e7ecc1921752a2eb7c2463a08ed9b6c96b85a2f75aa"
+            ],
+            "version": "==1.1.0"
         },
         "decorator": {
             "hashes": [
@@ -367,6 +388,20 @@
             ],
             "index": "pypi",
             "version": "==3.6.0"
+        },
+        "identify": {
+            "hashes": [
+                "sha256:5e956558a9a1e3b3891d7c6609fc9709657a11878af288ace484d1a46a93922b",
+                "sha256:623086059219cc7b86c77a3891f3700cb175d4ce02b8fb8802b047301d71e783"
+            ],
+            "version": "==1.1.7"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:36b02c84f9001adf65209fefdf951be8e9014a95eab9938c0779ad5670359b1c",
+                "sha256:60b6481a72908c93ccb707abeb926fb5a15319b9e6f0b76639a718837ee12de0"
+            ],
+            "version": "==0.6"
         },
         "ipdb": {
             "hashes": [
@@ -404,6 +439,12 @@
             ],
             "version": "==0.6.1"
         },
+        "nodeenv": {
+            "hashes": [
+                "sha256:ad8259494cf1c9034539f6cced78a1da4840a4b157e23640bc4a0c0546b0cb7a"
+            ],
+            "version": "==1.3.3"
+        },
         "parso": {
             "hashes": [
                 "sha256:35704a43a3c113cce4de228ddb39aab374b8004f4f2407d070b6a2ca784ce8a2",
@@ -425,6 +466,14 @@
                 "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56"
             ],
             "version": "==0.7.5"
+        },
+        "pre-commit": {
+            "hashes": [
+                "sha256:7542bd8ae1c58745175ea0a9295964ee82a10f7e18c4344f5e4c02bd85d02561",
+                "sha256:87f687da6a2651d5067cfec95b854b004e95b70143cbf2369604bb3acbce25ec"
+            ],
+            "index": "pypi",
+            "version": "==1.12.0"
         },
         "prompt-toolkit": {
             "hashes": [
@@ -462,6 +511,22 @@
             ],
             "version": "==2.2.0"
         },
+        "pyyaml": {
+            "hashes": [
+                "sha256:3d7da3009c0f3e783b2c873687652d83b1bbfd5c88e9813fb7e5b03c0dd3108b",
+                "sha256:3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf",
+                "sha256:40c71b8e076d0550b2e6380bada1f1cd1017b882f7e16f09a65be98e017f211a",
+                "sha256:558dd60b890ba8fd982e05941927a3911dc409a63dcb8b634feaa0cda69330d3",
+                "sha256:a7c28b45d9f99102fa092bb213aa12e0aaf9a6a1f5e395d36166639c1f96c3a1",
+                "sha256:aa7dd4a6a427aed7df6fb7f08a580d68d9b118d90310374716ae90b710280af1",
+                "sha256:bc558586e6045763782014934bfaf39d48b8ae85a2713117d16c39864085c613",
+                "sha256:d46d7982b62e0729ad0175a9bc7e10a566fc07b224d2c79fafb5e032727eaa04",
+                "sha256:d5eef459e30b09f5a098b9cea68bebfeb268697f78d647bd255a085371ac7f3f",
+                "sha256:e01d3203230e1786cd91ccfdc8f8454c8069c91bee3962ad93b87a4b2860f537",
+                "sha256:e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531"
+            ],
+            "version": "==3.13"
+        },
         "six": {
             "hashes": [
                 "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
@@ -469,12 +534,26 @@
             ],
             "version": "==1.11.0"
         },
+        "toml": {
+            "hashes": [
+                "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c",
+                "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
+            ],
+            "version": "==0.10.0"
+        },
         "traitlets": {
             "hashes": [
                 "sha256:9c4bd2d267b7153df9152698efb1050a5d84982d3384a37b2c1f7723ba3e7835",
                 "sha256:c6cb5e6f57c5a9bdaa40fa71ce7b4af30298fbab9ece9815b5d995ab6217c7d9"
             ],
             "version": "==4.3.2"
+        },
+        "virtualenv": {
+            "hashes": [
+                "sha256:686176c23a538ecc56d27ed9d5217abd34644823d6391cbeb232f42bf722baad",
+                "sha256:f899fafcd92e1150f40c8215328be38ff24b519cd95357fa6e78e006c7638208"
+            ],
+            "version": "==16.1.0"
         },
         "wcwidth": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -1,2 +1,69 @@
 # mr_roboto
 A fun IRC bot that help us on work days
+
+# Development
+
+Prior to start the development on mr_roboto it's necessary to follow some steps
+in order to setup the environment: [*virtual environment*][pipenv], [*database
+migration*][alembic] and [*pre-commit hooks*][pre-commit].
+
+## Virtual environment through [**Pipenv**][pipenv]
+
+The first thing you need to do after the `git clone` is setup the *virtual
+environment* using **pipenv** tool. This tool requires you have at least
+*Python3* (used in this project) and **Python3-pip** (or install **pipenv**
+directly through your system's package manager).
+
+```
+$ pip install --user pipenv
+$ cd <cloned-repo-folder>
+$ pipenv --python python3
+$ pipenv shell
+$ pipenv install --dev
+```
+
+Once it's done you're ready to start coding, but you still need the database
+setup in order to run it properly.
+
+## Database migration through [**alembic**][alembic]
+
+This tool will be the one to create and maintain your database running and
+up-to-date. Every time a new database relation (table) is created or modified
+you need to make sure to rerun the command:
+
+```
+$ pipenv run alembic upgrade head
+```
+
+## Compliance hook during code commit
+
+Git allow us to create hook for its different stages, like *commit*, *merge* and
+*push*. We've created one on *commit* stage to ensure some checking tools run
+before the code even reach the git remote server. The hook was created using
+[**pre-commit**][pre-commit] tool and in order to get it running correctly run:
+
+```
+$ pipenv run pre-commit install
+```
+
+From now on every time you hit `git commit` you're going to see some additional
+information from the commit hook tools in case something fails, otherwise
+nothing else will be prompted.
+
+**Note:** *To make sure the hooks got your changes correctly and will run the
+checking tools over it it's important to get them on **staging area** before
+actually commit it. Unstaged files being directly commited through `git commit
+-a` can lead to false results. Thus, please, whenever you need to actually
+commit something first add them to your staging area with `git add`.*
+
+## Running
+
+With the three steps done you can easily run mr_roboto:
+
+```
+$ python mr_roboto.py settings.ini
+```
+
+[pipenv]: https://pipenv.readthedocs.io/en/latest/
+[alembic]: https://alembic.sqlalchemy.org/en/latest/
+[pre-commit]: https://pre-commit.com/


### PR DESCRIPTION
A pre-commit hook to check flake8 standards in the changed code. It helps
preventing too many cycles between CI and developer to check && correct coding
style issues something. In this way we guarantee the code is following the
coding style rules before it even reach the remote source tree.

But it's important to remember to run 'pre-commit install' before you continue
your work after this commit or whenever you clone the project git repo. The
first time the hook runs it might take some time to finish (few seconds), but
it'll be true only for the first time.