### PR TITLE
Fixes excuse command

### DIFF
--- a/plugins/commands.py
+++ b/plugins/commands.py
@@ -36,10 +36,14 @@ class Commands(BasePlugin):
 
         %%excuse
         """
-        url = 'https://api.githunt.io/programmingexcuses'
+        url = 'http://programmingexcuses.com'
         async with aiohttp.ClientSession() as session:
             async with session.get(url) as response:
-                return await response.text()
+                response = await response.text()
+
+        if response:
+            # Extracts the message from the HTML document.
+            return re.sub(r'(^[\w\W]*<a .*?>|</a>[\w\W]*$)', '', response)
 
     @command(permission='view')
     async def horoscope(self, mask, target, args):


### PR DESCRIPTION
Fixes **!excuse** command by removing the unavailable API and pointing the request to the official website.

It's important to note that the official website is not a API, so it's necessary to parse the HTML document in order to retrieve the messages.

This is dangerous because any change in the document structure will probably break the parser, but it is the only option so far. As soon as a new free API appears this should be updated.

Solves part of the issue #33.