### PR TITLE
Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: run test migrate
+
+run:
+	pipenv run python mr_roboto.py
+
+test:
+	pipenv run pytest -v -x -p no:warnings --cov-report term-missing --cov=./
+
+migrate:
+	pipenv run alembic upgrade head


### PR DESCRIPTION
Adds Makefile to simplify command execution.

Instead of `$ pipenv run python mr_roboto.py` type `$ make run`.
Instead of `$ pipenv run alembic upgrade head` type `$ make migrate`.
Instead of `$ pipenv run pytest -v -x -p no:warnings --cov-report term-missing --cov=./` type `$ make test`.