### PR TITLE
Add i18n (internationalization) support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ settings.ini
 
 # Ignore local env files
 .env
+
+# Ignore locale files
+locale/

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,6 @@ test:
 
 migrate:
 	pipenv run alembic upgrade head
+
+translate:
+	pipenv run python -m i18n.translate -b

--- a/Pipfile
+++ b/Pipfile
@@ -22,6 +22,7 @@ watchdog = "*"
 dataset = "*"
 alembic = "*"
 python-decouple = "*"
+polib = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "09f178f7d235675ee553a5f307a013534cbf738e230fb6e8c7c4c6fd00a744eb"
+            "sha256": "1705828ed41223e87eff470cdfb947b1caf8befab85c726119f0bbcafe35ca1b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,35 +26,37 @@
         },
         "aiohttp": {
             "hashes": [
-                "sha256:199f1d106e2b44b6dacdf6f9245493c7d716b01d0b7fbe1959318ba4dc64d1f5",
-                "sha256:0155af66de8c21b8dba4992aaeeabf55503caefae00067a3b1139f86d0ec50ed",
-                "sha256:cc619d974c8c11fe84527e4b5e1c07238799a8c29ea1c1285149170524ba9303",
-                "sha256:09654a9eca62d1bd6d64aa44db2498f60a5c1e0ac4750953fdd79d5c88955e10",
-                "sha256:629102a193162e37102c50713e2e31dc9a2fe7ac5e481da83e5bb3c0cee700aa",
-                "sha256:acc89b29b5f4e2332d65cd1b7d10c609a75b88ef8925d487a611ca788432dfa4",
-                "sha256:a25237abf327530d9561ef751eef9511ab56fd9431023ca6f4803f1994104d72",
-                "sha256:87331d1d6810214085a50749160196391a712a13336cd02ce1c3ea3d05bcf8d5",
-                "sha256:a5cbd7157b0e383738b8e29d6e556fde8726823dae0e348952a61742b21aeb12",
-                "sha256:9cddaff94c0135ee627213ac6ca6d05724bfe6e7a356e5e09ec57bd3249510f6",
-                "sha256:d4392defd4648badaa42b3e101080ae3313e8f4787cb517efd3f5b8157eaefd6",
-                "sha256:c2bec436a2b5dafe5eaeb297c03711074d46b6eb236d002c13c42f25c4a8ce9d",
-                "sha256:296f30dedc9f4b9e7a301e5cc963012264112d78a1d3094cd83ef148fdf33ca1",
-                "sha256:9a02a04bbe581c8605ac423ba3a74999ec9d8bce7ae37977a3d38680f5780b6d",
-                "sha256:b05bd85cc99b06740aad3629c2585bda7b83bd86e080b44ba47faf905fdf1300",
-                "sha256:40d7ea570b88db017c51392349cf99b7aefaaddd19d2c78368aeb0bddde9d390",
-                "sha256:a97a516e02b726e089cffcde2eea0d3258450389bbac48cbe89e0f0b6e7b0366",
-                "sha256:e1c3c582ee11af7f63a34a46f0448fca58e59889396ffdae1f482085061a2889",
                 "sha256:00d198585474299c9c3b4f1d5de1a576cc230d562abc5e4a0e81d71a20a6ca55",
-                "sha256:6d5ec9b8948c3d957e75ea14d41e9330e1ac3fed24ec53766c780f82805140dc",
+                "sha256:0155af66de8c21b8dba4992aaeeabf55503caefae00067a3b1139f86d0ec50ed",
+                "sha256:09654a9eca62d1bd6d64aa44db2498f60a5c1e0ac4750953fdd79d5c88955e10",
+                "sha256:199f1d106e2b44b6dacdf6f9245493c7d716b01d0b7fbe1959318ba4dc64d1f5",
+                "sha256:296f30dedc9f4b9e7a301e5cc963012264112d78a1d3094cd83ef148fdf33ca1",
                 "sha256:368ed312550bd663ce84dc4b032a962fcb3c7cae099dbbd48663afc305e3b939",
-                "sha256:9c4c83f4fa1938377da32bc2d59379025ceeee8e24b89f72fcbccd8ca22dc9bf"
+                "sha256:40d7ea570b88db017c51392349cf99b7aefaaddd19d2c78368aeb0bddde9d390",
+                "sha256:629102a193162e37102c50713e2e31dc9a2fe7ac5e481da83e5bb3c0cee700aa",
+                "sha256:6d5ec9b8948c3d957e75ea14d41e9330e1ac3fed24ec53766c780f82805140dc",
+                "sha256:87331d1d6810214085a50749160196391a712a13336cd02ce1c3ea3d05bcf8d5",
+                "sha256:9a02a04bbe581c8605ac423ba3a74999ec9d8bce7ae37977a3d38680f5780b6d",
+                "sha256:9c4c83f4fa1938377da32bc2d59379025ceeee8e24b89f72fcbccd8ca22dc9bf",
+                "sha256:9cddaff94c0135ee627213ac6ca6d05724bfe6e7a356e5e09ec57bd3249510f6",
+                "sha256:a25237abf327530d9561ef751eef9511ab56fd9431023ca6f4803f1994104d72",
+                "sha256:a5cbd7157b0e383738b8e29d6e556fde8726823dae0e348952a61742b21aeb12",
+                "sha256:a97a516e02b726e089cffcde2eea0d3258450389bbac48cbe89e0f0b6e7b0366",
+                "sha256:acc89b29b5f4e2332d65cd1b7d10c609a75b88ef8925d487a611ca788432dfa4",
+                "sha256:b05bd85cc99b06740aad3629c2585bda7b83bd86e080b44ba47faf905fdf1300",
+                "sha256:c2bec436a2b5dafe5eaeb297c03711074d46b6eb236d002c13c42f25c4a8ce9d",
+                "sha256:cc619d974c8c11fe84527e4b5e1c07238799a8c29ea1c1285149170524ba9303",
+                "sha256:d4392defd4648badaa42b3e101080ae3313e8f4787cb517efd3f5b8157eaefd6",
+                "sha256:e1c3c582ee11af7f63a34a46f0448fca58e59889396ffdae1f482085061a2889"
             ],
+            "index": "pypi",
             "version": "==3.5.4"
         },
         "alembic": {
             "hashes": [
                 "sha256:505d41e01dc0c9e6d85c116d0d35dbb0a833dcb490bf483b75abeb06648864e8"
             ],
+            "index": "pypi",
             "version": "==1.0.8"
         },
         "argh": {
@@ -78,13 +80,6 @@
             ],
             "version": "==19.1.0"
         },
-        "banal": {
-            "hashes": [
-                "sha256:1a9aaa9f3925f2e7a8aba8cd55dccba9163cbec89fa324d6326313bcc138c221",
-                "sha256:491947e79c4c4b1e710a97f7e3885d4fd4e23b1f4fa1da022965fd63116beed7"
-            ],
-            "version": "==0.4.2"
-        },
         "chardet": {
             "hashes": [
                 "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
@@ -101,9 +96,10 @@
         },
         "dataset": {
             "hashes": [
-                "sha256:22305959711499b0da0464298f3589cd33cccf84cfdcce91dae352a528cb4821",
-                "sha256:06e6e8166a2ce12524ffbed97b82866caeaa2dd8e85ee65baccf3b815528e22e"
+                "sha256:06e6e8166a2ce12524ffbed97b82866caeaa2dd8e85ee65baccf3b815528e22e",
+                "sha256:22305959711499b0da0464298f3589cd33cccf84cfdcce91dae352a528cb4821"
             ],
+            "index": "pypi",
             "version": "==1.1.2"
         },
         "docopt": {
@@ -124,6 +120,7 @@
                 "sha256:66ee7040bd873d083cac09fd45b4d044f07f1c933f57f2d7209d2d8654de3cb0",
                 "sha256:d538a6d42506aac506d214fbff9c5da7061cf7ff7302e9148ac52ad276b2f72c"
             ],
+            "index": "pypi",
             "version": "==1.1.2"
         },
         "lxml": {
@@ -155,6 +152,7 @@
                 "sha256:f9c839806089d79de588ee1dde2dae05dc1156d3355dfeb2b51fde84d9c960ad",
                 "sha256:ff962953e2389226adc4d355e34a98b0b800984399153c6678f2367b11b4d4b8"
             ],
+            "index": "pypi",
             "version": "==4.3.2"
         },
         "mako": {
@@ -230,18 +228,19 @@
             ],
             "version": "==4.5.2"
         },
-        "normality": {
-            "hashes": [
-                "sha256:2d8536f2f1a5f4d23671110d7c2dbb9ae12039dba8e3c113faf183b406363389",
-                "sha256:94c1f8f72c14ffc82296351fafba70bcfdc6b4c79bc385318de1b1fbe9985b22"
-            ],
-            "version": "==1.0.0"
-        },
         "pathtools": {
             "hashes": [
                 "sha256:7c35c5421a39bb82e58018febd90e3b6e5db34c5443aaaf742b3f33d4655f1c0"
             ],
             "version": "==0.1.2"
+        },
+        "polib": {
+            "hashes": [
+                "sha256:93b730477c16380c9a96726c54016822ff81acfa553977fdd131f2b90ba858d7",
+                "sha256:fad87d13696127ffb27ea0882d6182f1a9cf8a5e2b37a587751166c51e5a332a"
+            ],
+            "index": "pypi",
+            "version": "==1.1.0"
         },
         "python-dateutil": {
             "hashes": [
@@ -259,11 +258,9 @@
         },
         "python-editor": {
             "hashes": [
-                "sha256:ea87e17f6ec459e780e4221f295411462e0d0810858e055fc514684350a2f522",
-                "sha256:5f98b069316ea1c2ed3f67e7f5df6c0d8f10b689964a4a811ff64f0106819ec8",
-                "sha256:c3da2053dbab6b29c94e43c486ff67206eafbe7eb52dbec7390b5e2fb05aac77",
                 "sha256:1bf6e860a8ad52a14c3ee1252d5dc25b2030618ed80c022598f00176adc8367d",
-                "sha256:51fda6bcc5ddbbb7063b2af7509e43bd84bfc32a4ff71349ec7847713882327b"
+                "sha256:51fda6bcc5ddbbb7063b2af7509e43bd84bfc32a4ff71349ec7847713882327b",
+                "sha256:5f98b069316ea1c2ed3f67e7f5df6c0d8f10b689964a4a811ff64f0106819ec8"
             ],
             "version": "==1.0.4"
         },
@@ -325,17 +322,17 @@
         },
         "yarl": {
             "hashes": [
-                "sha256:3e2724eb9af5dc41648e5bb304fcf4891adc33258c6e14e2a7414ea32541e320",
+                "sha256:024ecdc12bc02b321bc66b41327f930d1c2c543fa9a561b39861da9388ba7aa9",
+                "sha256:2f3010703295fbe1aec51023740871e64bb9664c789cba5a6bdf404e93f7568f",
                 "sha256:3890ab952d508523ef4881457c4099056546593fa05e93da84c7250516e632eb",
+                "sha256:3e2724eb9af5dc41648e5bb304fcf4891adc33258c6e14e2a7414ea32541e320",
+                "sha256:5badb97dd0abf26623a9982cd448ff12cb39b8e4c94032ccdedf22ce01a64842",
+                "sha256:73f447d11b530d860ca1e6b582f947688286ad16ca42256413083d13f260b7a0",
                 "sha256:7ab825726f2940c16d92aaec7d204cfc34ac26c0040da727cf8ba87255a33829",
                 "sha256:b25de84a8c20540531526dfbb0e2d2b648c13fd5dd126728c496d7c3fea33310",
-                "sha256:2f3010703295fbe1aec51023740871e64bb9664c789cba5a6bdf404e93f7568f",
-                "sha256:5badb97dd0abf26623a9982cd448ff12cb39b8e4c94032ccdedf22ce01a64842",
-                "sha256:c9bb7c249c4432cd47e75af3864bc02d26c9594f49c82e2a28624417f0ae63b8",
                 "sha256:c6e341f5a6562af74ba55205dbd56d248daf1b5748ec48a0200ba227bb9e33f4",
-                "sha256:e060906c0c585565c718d1c3841747b61c5439af2211e185f6739a9412dfbde1",
-                "sha256:73f447d11b530d860ca1e6b582f947688286ad16ca42256413083d13f260b7a0",
-                "sha256:024ecdc12bc02b321bc66b41327f930d1c2c543fa9a561b39861da9388ba7aa9"
+                "sha256:c9bb7c249c4432cd47e75af3864bc02d26c9594f49c82e2a28624417f0ae63b8",
+                "sha256:e060906c0c585565c718d1c3841747b61c5439af2211e185f6739a9412dfbde1"
             ],
             "version": "==1.3.0"
         }
@@ -386,13 +383,6 @@
             ],
             "version": "==0.1.0"
         },
-        "cached-property": {
-            "hashes": [
-                "sha256:3a026f1a54135677e7da5ce819b0c690f156f37976f3e30c5430740725203d7f",
-                "sha256:9217a59f14a5682da7c4b8829deadbfc194ac22e9908ccf7c8820234e80a1504"
-            ],
-            "version": "==1.5.1"
-        },
         "certifi": {
             "hashes": [
                 "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
@@ -424,42 +414,32 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:0c5fe441b9cfdab64719f24e9684502a59432df7570521563d7b1aff27ac755f",
-                "sha256:2b412abc4c7d6e019ce7c27cbc229783035eef6d5401695dccba80f481be4eb3",
                 "sha256:3684fabf6b87a369017756b551cef29e505cb155ddb892a7a29277b978da88b9",
                 "sha256:39e088da9b284f1bd17c750ac672103779f7954ce6125fd4382134ac8d152d74",
                 "sha256:3c205bc11cc4fcc57b761c2da73b9b72a59f8d5ca89979afb0c1c6f9e53c7390",
-                "sha256:42692db854d13c6c5e9541b6ffe0fe921fe16c9c446358d642ccae1462582d3b",
                 "sha256:465ce53a8c0f3a7950dfb836438442f833cf6663d407f37d8c52fe7b6e56d7e8",
                 "sha256:48020e343fc40f72a442c8a1334284620f81295256a6b6ca6d8aa1350c763bbe",
-                "sha256:4ec30ade438d1711562f3786bea33a9da6107414aed60a5daa974d50a8c2c351",
                 "sha256:5296fc86ab612ec12394565c500b412a43b328b3907c0d14358950d06fd83baf",
                 "sha256:5f61bed2f7d9b6a9ab935150a6b23d7f84b8055524e7be7715b6513f3328138e",
-                "sha256:6899797ac384b239ce1926f3cb86ffc19996f6fa3a1efbb23cb49e0c12d8c18c",
                 "sha256:68a43a9f9f83693ce0414d17e019daee7ab3f7113a70c79a3dd4c2f704e4d741",
                 "sha256:6b8033d47fe22506856fe450470ccb1d8ba1ffb8463494a15cfc96392a288c09",
                 "sha256:7ad7536066b28863e5835e8cfeaa794b7fe352d99a8cded9f43d1161be8e9fbd",
                 "sha256:7bacb89ccf4bedb30b277e96e4cc68cd1369ca6841bde7b005191b54d3dd1034",
                 "sha256:839dc7c36501254e14331bcb98b27002aa415e4af7ea039d9009409b9d2d5420",
-                "sha256:8e679d1bde5e2de4a909efb071f14b472a678b788904440779d2c449c0355b27",
                 "sha256:8f9a95b66969cdea53ec992ecea5406c5bd99c9221f539bca1e8406b200ae98c",
                 "sha256:932c03d2d565f75961ba1d3cec41ddde00e162c5b46d03f7423edcb807734eab",
-                "sha256:93f965415cc51604f571e491f280cff0f5be35895b4eb5e55b47ae90c02a497b",
                 "sha256:988529edadc49039d205e0aa6ce049c5ccda4acb2d6c3c5c550c17e8c02c05ba",
                 "sha256:998d7e73548fe395eeb294495a04d38942edb66d1fa61eb70418871bc621227e",
                 "sha256:9de60893fb447d1e797f6bf08fdf0dbcda0c1e34c1b06c92bd3a363c0ea8c609",
                 "sha256:9e80d45d0c7fcee54e22771db7f1b0b126fb4a6c0a2e5afa72f66827207ff2f2",
                 "sha256:a545a3dfe5082dc8e8c3eb7f8a2cf4f2870902ff1860bd99b6198cfd1f9d1f49",
                 "sha256:a5d8f29e5ec661143621a8f4de51adfb300d7a476224156a39a392254f70687b",
-                "sha256:a9abc8c480e103dc05d9b332c6cc9fb1586330356fc14f1aa9c0ca5745097d19",
                 "sha256:aca06bfba4759bbdb09bf52ebb15ae20268ee1f6747417837926fae990ebc41d",
                 "sha256:bb23b7a6fd666e551a3094ab896a57809e010059540ad20acbeec03a154224ce",
                 "sha256:bfd1d0ae7e292105f29d7deaa9d8f2916ed8553ab9d5f39ec65bcf5deadff3f9",
-                "sha256:c22ab9f96cbaff05c6a84e20ec856383d27eae09e511d3e6ac4479489195861d",
                 "sha256:c62ca0a38958f541a73cf86acdab020c2091631c137bd359c4f5bddde7b75fd4",
                 "sha256:c709d8bda72cf4cd348ccec2a4881f2c5848fd72903c185f363d361b2737f773",
                 "sha256:c968a6aa7e0b56ecbd28531ddf439c2ec103610d3e2bf3b75b813304f8cb7723",
-                "sha256:ca58eba39c68010d7e87a823f22a081b5290e3e3c64714aac3c91481d8b34d22",
                 "sha256:df785d8cb80539d0b55fd47183264b7002077859028dfe3070cf6359bf8b2d9c",
                 "sha256:f406628ca51e0ae90ae76ea8398677a921b36f0bd71aab2099dfed08abd0322f",
                 "sha256:f46087bbd95ebae244a0eda01a618aff11ec7a069b15a3ef8f6b520db523dcf1",
@@ -475,11 +455,19 @@
             ],
             "version": "==4.4.0"
         },
+        "entrypoints": {
+            "hashes": [
+                "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19",
+                "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"
+            ],
+            "version": "==0.3"
+        },
         "flake8": {
             "hashes": [
                 "sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661",
                 "sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8"
             ],
+            "index": "pypi",
             "version": "==3.7.7"
         },
         "identify": {
@@ -507,6 +495,7 @@
             "hashes": [
                 "sha256:dce2112557edfe759742ca2d0fee35c59c97b0cc7a05398b791079d78f1519ce"
             ],
+            "index": "pypi",
             "version": "==0.12"
         },
         "ipython": {
@@ -542,6 +531,7 @@
                 "sha256:0125e8f60e9e031347105eb1682cef932f5e97d7b9a1a28d9bf00c22a5daef40",
                 "sha256:590044e3942351a1bdb1de960b739ff4ce277960f2425ad4509446dbace8d9d1"
             ],
+            "markers": "python_version > '2.7'",
             "version": "==6.0.0"
         },
         "nodeenv": {
@@ -584,6 +574,7 @@
                 "sha256:d3d69c63ae7b7584c4b51446b0b583d454548f9df92575b2fe93a68ec800c4d3",
                 "sha256:fc512f129b9526e35e80d656a16a31c198f584c4fce3a5c739045b5140584917"
             ],
+            "index": "pypi",
             "version": "==1.14.4"
         },
         "prompt-toolkit": {
@@ -624,8 +615,8 @@
         },
         "pygments": {
             "hashes": [
-                "sha256:e8218dd399a61674745138520d0d4cf2621d7e032439341bc3f647bff125818d",
-                "sha256:5ffada19f6203563680669ee7f53b64dabbeb100eb51b61996085e99c03b284a"
+                "sha256:5ffada19f6203563680669ee7f53b64dabbeb100eb51b61996085e99c03b284a",
+                "sha256:e8218dd399a61674745138520d0d4cf2621d7e032439341bc3f647bff125818d"
             ],
             "version": "==2.3.1"
         },
@@ -634,13 +625,15 @@
                 "sha256:592eaa2c33fae68c7d75aacf042efc9f77b27c08a6224a4f59beab8d9a420523",
                 "sha256:ad3ad5c450284819ecde191a654c09b0ec72257a2c711b9633d677c71c9850c4"
             ],
+            "index": "pypi",
             "version": "==4.3.1"
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:230ef817450ab0699c6cc3c9c8f7a829c34674456f2ed8df1fe1d39780f7c87f",
-                "sha256:0ab664b25c6aa9716cbf203b17ddb301932383046082c081b9848a0edf5add33"
+                "sha256:0ab664b25c6aa9716cbf203b17ddb301932383046082c081b9848a0edf5add33",
+                "sha256:230ef817450ab0699c6cc3c9c8f7a829c34674456f2ed8df1fe1d39780f7c87f"
             ],
+            "index": "pypi",
             "version": "==2.6.1"
         },
         "pyyaml": {
@@ -661,8 +654,8 @@
         },
         "requests": {
             "hashes": [
-                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b",
-                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e"
+                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
+                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
             ],
             "version": "==2.21.0"
         },
@@ -707,6 +700,13 @@
                 "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"
             ],
             "version": "==0.1.7"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:55ca87266c38af6658b84db8cfb7343cdb0bf275f93c7afaea0d8e7a209c7478",
+                "sha256:682b3e1c62b7026afe24eadf6be579fb45fec54c07ea218bded8092af07a68c4"
+            ],
+            "version": "==0.3.3"
         }
     }
 }

--- a/i18n/catalog.py
+++ b/i18n/catalog.py
@@ -1,0 +1,85 @@
+# For new languages support add the desired lang codes here. The codes
+# must follow the two-letter lower case abbreviation according to the
+# ISO639-1 (https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).
+# e.g.: fr (french), de (german), pt (portuguese), and so on.
+languages = ['en']
+
+# Add here the text that should be translated. An entry is a python
+# dictionary and must have at least a `msgid` field with the text in
+# english as it is the default language. The text translated goes just
+# after the `msgid` and the key is the language code. The following
+# example is an entry with a text in english, portuguese and spanish.
+# e.g.:
+#
+# {
+#     'msgid': 'Hello world',
+#     'pt': 'Olá mundo',
+#     'es': 'Hola mundo'
+# }
+entries = [
+    {
+        'msgid': 'Good morning'
+    },
+    {
+        'msgid': 'Good morning fellas'
+    },
+    {
+        'msgid': 'Morning'
+    },
+    {
+        'msgid': 'Hello everyone'
+    },
+    {
+        'msgid': 'I definitely need a coffee. Oh, hello btw.'
+    },
+    {
+        'msgid': 'Lunch time'
+    },
+    {
+        'msgid': 'I\'m gonna get something to eat'
+    },
+    {
+        'msgid': '{nick}: Hi!'
+    },
+    {
+        'msgid': 'Booom shakalaka'
+    },
+    {
+        'msgid': 'It seems this site has a broken charset'
+    },
+    {
+        'msgid': 'Looks like an image'
+    },
+    {
+        'msgid': 'Do you know I\'m deaf right?'
+    },
+    {
+        'msgid': 'For God sake I\'m blind'
+    },
+    {
+        'msgid': 'What kind of weed is that?'
+    },
+    {
+        'msgid': 'My sources say that this links does not exists'
+    },
+    {
+        'msgid': 'I\'m sorry but the stars seems to be unreachable.'
+    },
+    {
+        'msgid': 'Okie dokie'
+    },
+    {
+        'msgid': 'Sorry, looks like something went wrong :('
+    },
+    {
+        'msgid': 'All work and no play makes Jack a dull boy'
+    },
+    {
+        'msgid': (
+            'Hi there, my name is {nick} and I am an IRC bot '
+            'written in Python. If you wanna know more about me take '
+            'a look at my Github page https://github.com/meleca/mr-roboto/. '
+            'Currently running v{version}.'
+        )
+    }
+]

--- a/i18n/translate.py
+++ b/i18n/translate.py
@@ -1,0 +1,58 @@
+import argparse
+import datetime
+import gettext
+import os
+import polib
+from i18n import catalog
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+LOCALE_DIR = os.path.join(ROOT_DIR, 'locale')
+NAMESPACE = 'mr_roboto'
+
+
+def translation():
+    """Return a translation instance according
+    to the namespace and locale."""
+    return gettext.translation(NAMESPACE, LOCALE_DIR, fallback=True)
+
+
+# Set an alias for the translation method
+_ = translation().gettext
+
+
+def build():
+    """Build translation catalogs."""
+    metadata = {
+        'POT-Creation-Date': datetime.datetime.now(),
+        'PO-Revision-Date': datetime.datetime.now(),
+        'MIME-Version': '1.0',
+        'Content-Type': 'text/plain; charset=utf-8',
+        'Content-Transfer-Encoding': '8bit'
+    }
+    for lang in catalog.languages:
+        po = polib.POFile()
+        po.metadata = metadata
+        for entry in catalog.entries:
+            po.append(
+                polib.POEntry(
+                    msgid=entry['msgid'],
+                    msgstr=entry.get(lang, '')
+                )
+            )
+        path = os.path.join(LOCALE_DIR, lang, 'LC_MESSAGES')
+        if not os.path.isdir(path):
+            os.makedirs(path)
+        po.save(os.path.join(path, f'{NAMESPACE}.po'))
+        po.save_as_mofile(os.path.join(path, f'{NAMESPACE}.mo'))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Internationalization utils.')
+    parser.add_argument(
+        '-b', '--build',
+        action='store_true',
+        help='build translation catalogs'
+    )
+    args = parser.parse_args()
+    if args.build:
+        build()

--- a/plugins/behaviors.py
+++ b/plugins/behaviors.py
@@ -1,3 +1,4 @@
+from i18n.translate import _
 from irc3 import plugin, event, rfc
 from irc3.plugins.cron import cron
 from lxml import html
@@ -54,11 +55,11 @@ class Behaviors(BasePlugin):
         Automatic sends a random message every week day 9am.
         """
         feeling_sleepy = [
-            'Good morning',
-            'Good morning fellas',
-            'Morning',
-            'Hello everyone',
-            'I definitely need a coffee. Oh, hello btw.'
+            _('Good morning'),
+            _('Good morning fellas'),
+            _('Morning'),
+            _('Hello everyone'),
+            _('I definitely need a coffee. Oh, hello btw.')
         ]
         to_say = random.choice(feeling_sleepy)
 
@@ -71,7 +72,10 @@ class Behaviors(BasePlugin):
 
         Automatic sends a random message every week day 12pm.
         """
-        feeling_hungry = ['Lunch time', 'I\'m gonna get something to eat']
+        feeling_hungry = [
+            _('Lunch time'),
+            _('I\'m gonna get something to eat')
+        ]
         to_say = random.choice(feeling_hungry)
 
         for channel in list(self.bot.channels):
@@ -86,7 +90,7 @@ class Behaviors(BasePlugin):
             channel: Channel name.
         """
         if self.bot.nick != mask.nick:
-            message = f'{mask.nick}: Hi!'
+            message = _('{nick}: Hi!').format(nick=mask.nick)
             nick = mask.nick.lower()
             table = self.bot.dataset['greetings']
             result = table.find_one(channel=channel.replace('#', ''),
@@ -121,7 +125,7 @@ class Behaviors(BasePlugin):
 
             except Exception as e:
                 print(e)
-                self.bot.privmsg(target, 'Booom shakalaka')
+                self.bot.privmsg(target, _('Booom shakalaka'))
 
         await self.slack_meter(target, mask.nick, data)
 
@@ -154,7 +158,7 @@ class Behaviors(BasePlugin):
                     return
                 else:
                     self.bot.privmsg(
-                        target, 'It seems this site has a broken charset')
+                        target, _('It seems this site has a broken charset'))
                     return
 
             page = html.fromstring(content)
@@ -165,16 +169,16 @@ class Behaviors(BasePlugin):
                 self.bot.privmsg(target, f'[{history.get("title")}]')
 
         def handle_image(target, subtype, data):
-            self.bot.privmsg(target, 'Looks like an image')
+            self.bot.privmsg(target, _('Looks like an image'))
 
         def handle_audio(target, subtype, data):
-            self.bot.privmsg(target, 'Do you know I\'m deaf right?')
+            self.bot.privmsg(target, _('Do you know I\'m deaf right?'))
 
         def handle_video(target, subtype, data):
-            self.bot.privmsg(target, 'For God sake I\'m blind')
+            self.bot.privmsg(target, _('For God sake I\'m blind'))
 
         def handle_default(target, subtype, data):
-            self.bot.privmsg(target, 'What kind of weed is that?')
+            self.bot.privmsg(target, _('What kind of weed is that?'))
 
         type_handlers = {
             u'text': handle_text,
@@ -191,7 +195,7 @@ class Behaviors(BasePlugin):
                 if not match:
                     self.bot.privmsg(
                         target,
-                        'My sources say that this links does not exists')
+                        _('My sources say that this links does not exists'))
                     return
 
                 mime_type = match.group(1)

--- a/plugins/commands.py
+++ b/plugins/commands.py
@@ -1,3 +1,4 @@
+from i18n.translate import _
 from irc3 import plugin
 from irc3.plugins.command import command
 import aiohttp
@@ -68,7 +69,7 @@ class Commands(BasePlugin):
             async with session.get(url) as response:
                 response = await response.json()
 
-        msg = 'I\'m sorry but the stars seems to be unreachable.'
+        msg = _('I\'m sorry but the stars seems to be unreachable.')
         if response:
             horoscope = response.get('horoscope', '')
             if horoscope:
@@ -95,9 +96,9 @@ class Commands(BasePlugin):
                 'options': options,
             }, ['channel', 'nick'])
 
-            return 'Okie dokie'
+            return _('Okie dokie')
         except Exception:
-            return 'Sorry, looks like something went wrong :('
+            return _('Sorry, looks like something went wrong :(')
 
     @command(permission='view')
     async def joke(self, mask, target, args):
@@ -148,7 +149,7 @@ class Commands(BasePlugin):
 
         except Exception as e:
             print(e)
-            return 'All work and no play makes Jack a dull boy'
+            return _('All work and no play makes Jack a dull boy')
 
     @command(permission='view')
     async def cebolate(self, mask, target, args):
@@ -262,10 +263,10 @@ class Commands(BasePlugin):
 
         %%about
         """
-        message = (
-            f'Hi there, my name is {self.bot.nick} and I am an IRC bot '
+        message = _((
+            'Hi there, my name is {nick} and I am an IRC bot '
             'written in Python. If you wanna know more about me take '
             'a look at my Github page https://github.com/meleca/mr-roboto/. '
-            f'Currently running v{self.bot.version}.'
-        )
+            'Currently running v{version}.'
+        )).format(nick=self.bot.nick, version=self.bot.version)
         self.bot.privmsg(target, message)

--- a/test/test_catalog.py
+++ b/test/test_catalog.py
@@ -1,0 +1,17 @@
+from i18n import catalog
+
+
+def test_languages():
+    """Tests if all languages code follows the pattern."""
+    assert all(
+        len(lang) == 2 and lang.islower()
+        for lang in catalog.languages
+    )
+
+
+def test_entries():
+    """Tests if all entries have a valid msgid."""
+    assert all(
+        'msgid' in entry.keys() and entry['msgid']
+        for entry in catalog.entries
+    )

--- a/test/test_translate.py
+++ b/test/test_translate.py
@@ -1,0 +1,30 @@
+import gettext
+from i18n import catalog, translate
+import os
+import shutil
+
+
+def test_translation():
+    """Tests if the translation function returns a Translation
+    instance.
+
+    The translation object returned can be both a GNUTranslations or
+    a NullTranslations depending if there's a locale directory with
+    valid translations or not.
+    """
+    gt = translate.translation()
+    assert isinstance(gt, gettext.NullTranslations)
+
+
+def test_build():
+    """Tests if the build function produces the appropriate
+    localization files."""
+    if os.path.isdir(translate.LOCALE_DIR):
+        shutil.rmtree(translate.LOCALE_DIR)
+    translate.build()
+    for lang in catalog.languages:
+        path = os.path.join(translate.LOCALE_DIR, lang, 'LC_MESSAGES')
+        po_file = os.path.join(path, f'{translate.NAMESPACE}.po')
+        mo_file = os.path.join(path, f'{translate.NAMESPACE}.mo')
+        assert os.path.isfile(po_file)
+        assert os.path.isfile(mo_file)


### PR DESCRIPTION
Initial support for internationalization using [gettext](https://docs.python.org/3/library/gettext.html) combined with [polib](https://polib.readthedocs.io).

From now on as part of the installation process it's necessary to generate the localized files. Also, when changes in `i18n/catalog.py` are made it's necessary to re-generate these files too.

To generate the localized files just run:

```
$ make translate
```

In order to add support for more languages or translate any piece of text all that have to be done is make changes in `i18n/catalog.py` file. For more details see the comments in the file.

Solves issue #1 